### PR TITLE
Expose IClient trait and ClientVariant as public. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dgraph-tonic"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Selmeci <selmeci.roman@gmail.com>"]
 edition = "2018"
 description = "A rust async/async client for Dgraph database build with Tonic crate"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ pub use crate::client::{
 pub use crate::client::{
     AclTlsClient, TxnAclTls, TxnAclTlsBestEffort, TxnAclTlsMutated, TxnAclTlsReadOnly,
 };
-pub use crate::client::{Client, Txn, TxnBestEffort, TxnMutated, TxnReadOnly};
+pub use crate::client::{
+    Client, ClientVariant, IClient, Txn, TxnBestEffort, TxnMutated, TxnReadOnly,
+};
 #[cfg(feature = "tls")]
 pub use crate::client::{TlsClient, TxnTls, TxnTlsBestEffort, TxnTlsMutated, TxnTlsReadOnly};
 pub use crate::errors::{ClientError, DgraphError};


### PR DESCRIPTION
dgraph-tonic clients can use it in structures or as function parameters