### PR TITLE
Remove failure dependency + future-proof errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ exclude = [
 [dependencies]
 async-stream = "0.2"
 async-trait = "0.1"
-failure = "0.1"
 futures = "0.3"
 http = "0.2"
 lazy_static = "1.4"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,11 +1,11 @@
-use failure::Error;
-
 use async_trait::async_trait;
 
 #[cfg(feature = "dgraph-1-0")]
 pub use crate::api::v1_0_x::*;
 #[cfg(feature = "dgraph-1-1")]
 pub use crate::api::v1_1_x::*;
+
+use crate::ClientError;
 
 mod mutation;
 mod response;
@@ -16,19 +16,19 @@ mod v1_1_x;
 #[async_trait]
 #[doc(hidden)]
 pub(crate) trait IDgraphClient: Clone + Sized {
-    async fn login(&mut self, login: LoginRequest) -> Result<Response, Error>;
+    async fn login(&mut self, login: LoginRequest) -> Result<Response, ClientError>;
 
-    async fn query(&mut self, query: Request) -> Result<Response, Error>;
+    async fn query(&mut self, query: Request) -> Result<Response, ClientError>;
 
     #[cfg(feature = "dgraph-1-0")]
-    async fn mutate(&mut self, mu: Mutation) -> Result<Assigned, Error>;
+    async fn mutate(&mut self, mu: Mutation) -> Result<Assigned, ClientError>;
 
     #[cfg(feature = "dgraph-1-1")]
-    async fn do_request(&mut self, req: Request) -> Result<Response, Error>;
+    async fn do_request(&mut self, req: Request) -> Result<Response, ClientError>;
 
-    async fn alter(&mut self, op: Operation) -> Result<Payload, Error>;
+    async fn alter(&mut self, op: Operation) -> Result<Payload, ClientError>;
 
-    async fn commit_or_abort(&mut self, txn: TxnContext) -> Result<TxnContext, Error>;
+    async fn commit_or_abort(&mut self, txn: TxnContext) -> Result<TxnContext, ClientError>;
 
-    async fn check_version(&mut self) -> Result<Version, Error>;
+    async fn check_version(&mut self) -> Result<Version, ClientError>;
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 
-use failure::Error;
 use http::Uri;
 use rand::Rng;
 
@@ -56,7 +55,7 @@ pub(crate) fn rnd_item<T: Clone>(items: &[T]) -> T {
 ///
 pub(crate) fn balance_list<U: TryInto<Uri>, E: Into<Endpoints<U>>>(
     endpoints: E,
-) -> Result<Vec<Uri>, Error> {
+) -> Result<Vec<Uri>, ClientError> {
     let endpoints: Endpoints<U> = endpoints.into();
     let mut balance_list: Vec<Uri> = Vec::new();
     for maybe_endpoint in endpoints.endpoints {
@@ -217,7 +216,7 @@ impl<C: IClient> ClientVariant<C> {
     /// }
     /// ```
     ///
-    pub async fn alter(&self, op: Operation) -> Result<Payload, Error> {
+    pub async fn alter(&self, op: Operation) -> Result<Payload, ClientError> {
         let mut stub = self.any_stub();
         stub.alter(op).await
     }
@@ -262,7 +261,7 @@ impl<C: IClient> ClientVariant<C> {
     /// }
     /// ```
     ///
-    pub async fn set_schema<S: Into<String>>(&self, schema: S) -> Result<Payload, Error> {
+    pub async fn set_schema<S: Into<String>>(&self, schema: S) -> Result<Payload, ClientError> {
         let op = Operation {
             schema: schema.into(),
             ..Default::default()
@@ -306,7 +305,7 @@ impl<C: IClient> ClientVariant<C> {
     /// }
     /// ```
     ///
-    pub async fn drop_all(&self) -> Result<Payload, Error> {
+    pub async fn drop_all(&self) -> Result<Payload, ClientError> {
         let op = Operation {
             drop_all: true,
             ..Default::default()
@@ -335,7 +334,7 @@ impl<C: IClient> ClientVariant<C> {
     /// }
     /// ```
     ///
-    pub async fn check_version(&self) -> Result<Version, Error> {
+    pub async fn check_version(&self) -> Result<Version, ClientError> {
         let mut stub = self.any_stub();
         stub.check_version().await
     }

--- a/src/errors/client.rs
+++ b/src/errors/client.rs
@@ -4,6 +4,7 @@ use crate::Status;
 /// Possible errors for client
 ///
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     InvalidEndpoint,
     NoEndpointsDefined,

--- a/src/errors/client.rs
+++ b/src/errors/client.rs
@@ -1,29 +1,39 @@
 use crate::Status;
-use failure::Fail;
 
 ///
 /// Possible errors for client
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 pub enum Error {
-    #[fail(display = "Client: invalid endpoint")]
     InvalidEndpoint,
-    #[fail(display = "Client: no endpoints defined")]
     NoEndpointsDefined,
-    #[fail(display = "Client: cannot do alter on DB")]
     CannotAlter(Status),
-    #[fail(display = "Client: cannot login")]
     CannotLogin(Status),
-    #[fail(display = "Client: cannot refresh login")]
     CannotRefreshLogin(Status),
-    #[fail(display = "Client: cannot query")]
     CannotQuery(Status),
-    #[fail(display = "Client: cannot mutate")]
     CannotMutate(Status),
-    #[fail(display = "Client: cannot do request")]
     CannotDoRequest(Status),
-    #[fail(display = "Client: cannot commit or abort")]
     CannotCommitOrAbort(Status),
-    #[fail(display = "Client: cannot check version")]
     CannotCheckVersion(Status),
+    Transport(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Error::InvalidEndpoint => write!(f, "Client: invalid endpoint"),
+            Error::NoEndpointsDefined => write!(f, "Client: no endpoints defined"),
+            Error::CannotAlter(_) => write!(f, "Client: cannot do alter on DB"),
+            Error::CannotLogin(_) => write!(f, "Client: cannot login"),
+            Error::CannotRefreshLogin(_) => write!(f, "Client: cannot refresh login"),
+            Error::CannotQuery(_) => write!(f, "Client: cannot query"),
+            Error::CannotMutate(_) => write!(f, "Client: cannot mutate"),
+            Error::CannotDoRequest(_) => write!(f, "Client: cannot do request"),
+            Error::CannotCommitOrAbort(_) => write!(f, "Client: cannot commit or abort"),
+            Error::CannotCheckVersion(_) => write!(f, "Client: cannot check version"),
+            Error::Transport(e) => write!(f, "Transport error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/errors/dgraph.rs
+++ b/src/errors/dgraph.rs
@@ -1,18 +1,23 @@
-use failure::{Error as Failure, Fail};
-
 ///
 /// Possible Dgraph errors
 ///
-#[derive(Debug, Fail)]
+#[derive(Debug)]
 pub enum Error {
-    #[fail(display = "Dgraph: Txn start mismatch")]
     StartTsMismatch,
-    #[fail(display = "Dgraph: gRPC communication Error")]
-    GrpcError(Failure),
-    #[fail(display = "Dgraph: Txn is empty")]
+    GrpcError(super::ClientError),
     EmptyTxn,
-    #[fail(display = "Dgraph: Missing Txn context")]
     MissingTxnContext,
-    #[fail(display = "Dgraph: Txn is already committed")]
     TxnCommitted,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::StartTsMismatch => write!(f, "Dgraph: Txn start mismatch"),
+            Error::GrpcError(err) => write!(f, "Dgraph: gRPC communication Error - {}", err),
+            Error::EmptyTxn => write!(f, "Dgraph: Txn is empty"),
+            Error::MissingTxnContext => write!(f, "Dgraph: Missing Txn context)"),
+            Error::TxnCommitted => write!(f, "Dgraph: Txn is already committed"),
+        }
+    }
 }

--- a/src/errors/dgraph.rs
+++ b/src/errors/dgraph.rs
@@ -2,6 +2,7 @@
 /// Possible Dgraph errors
 ///
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     StartTsMismatch,
     GrpcError(super::ClientError),

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -1,4 +1,3 @@
-use failure::Error;
 use tonic::Request;
 
 use async_trait::async_trait;
@@ -27,21 +26,21 @@ impl<C: ILazyClient> Stub<C> {
 
 #[async_trait]
 impl<C: ILazyClient> IDgraphClient for Stub<C> {
-    async fn login(&mut self, login: LoginRequest) -> Result<DgraphResponse, Error> {
+    async fn login(&mut self, login: LoginRequest) -> Result<DgraphResponse, ClientError> {
         let request = Request::new(login);
         let client = self.client.client().await?;
         match client.login(request).await {
             Ok(response) => Ok(response.into_inner()),
-            Err(status) => Err(ClientError::CannotLogin(status).into()),
+            Err(status) => Err(ClientError::CannotLogin(status)),
         }
     }
 
-    async fn query(&mut self, query: DgraphRequest) -> Result<DgraphResponse, Error> {
+    async fn query(&mut self, query: DgraphRequest) -> Result<DgraphResponse, ClientError> {
         let request = Request::new(query);
         let client = self.client.client().await?;
         match client.query(request).await {
             Ok(response) => Ok(response.into_inner()),
-            Err(status) => Err(ClientError::CannotQuery(status).into()),
+            Err(status) => Err(ClientError::CannotQuery(status)),
         }
     }
 
@@ -56,39 +55,39 @@ impl<C: ILazyClient> IDgraphClient for Stub<C> {
     }
 
     #[cfg(feature = "dgraph-1-1")]
-    async fn do_request(&mut self, req: DgraphRequest) -> Result<DgraphResponse, Error> {
+    async fn do_request(&mut self, req: DgraphRequest) -> Result<DgraphResponse, ClientError> {
         let request = Request::new(req);
         let client = self.client.client().await?;
         match client.query(request).await {
             Ok(response) => Ok(response.into_inner()),
-            Err(status) => Err(ClientError::CannotDoRequest(status).into()),
+            Err(status) => Err(ClientError::CannotDoRequest(status)),
         }
     }
 
-    async fn alter(&mut self, op: Operation) -> Result<Payload, Error> {
+    async fn alter(&mut self, op: Operation) -> Result<Payload, ClientError> {
         let request = Request::new(op);
         let client = self.client.client().await?;
         match client.alter(request).await {
             Ok(response) => Ok(response.into_inner()),
-            Err(status) => Err(ClientError::CannotAlter(status).into()),
+            Err(status) => Err(ClientError::CannotAlter(status)),
         }
     }
 
-    async fn commit_or_abort(&mut self, txn: TxnContext) -> Result<TxnContext, Error> {
+    async fn commit_or_abort(&mut self, txn: TxnContext) -> Result<TxnContext, ClientError> {
         let request = Request::new(txn);
         let client = self.client.client().await?;
         match client.commit_or_abort(request).await {
             Ok(response) => Ok(response.into_inner()),
-            Err(status) => Err(ClientError::CannotCommitOrAbort(status).into()),
+            Err(status) => Err(ClientError::CannotCommitOrAbort(status)),
         }
     }
 
-    async fn check_version(&mut self) -> Result<Version, Error> {
+    async fn check_version(&mut self) -> Result<Version, ClientError> {
         let request = Request::new(Check {});
         let client = self.client.client().await?;
         match client.check_version(request).await {
             Ok(response) => Ok(response.into_inner()),
-            Err(status) => Err(ClientError::CannotCheckVersion(status).into()),
+            Err(status) => Err(ClientError::CannotCheckVersion(status)),
         }
     }
 }

--- a/src/txn/default.rs
+++ b/src/txn/default.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use crate::client::ILazyClient;
 use crate::stub::Stub;
 use crate::txn::{IState, TxnState, TxnVariant};
 use crate::Request;
-use failure::_core::marker::PhantomData;
 
 ///
 /// Inner state for default transaction


### PR DESCRIPTION
Removes failure and implements `std::error::Error` by hand.

Also future-proofs the error enums by adding `#[non_exhaustive]`.

Note that this is obviously a breaking change and will require a version bump.

Fixes #19 