### PR TITLE
Update dependencies - specifically, tokio, prost, and tonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,22 +22,22 @@ async-trait = "0.1"
 futures = "0.3"
 http = "0.2"
 lazy_static = "1.4"
-prost = "0.6"
+prost = "0.7"
 rand = "0.7"
 rustls = {version = "0.18", features = ["dangerous_configuration"], optional = true}
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
-tonic = {version = "0.3", features = ["tls"]}
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tonic = {version = "0.4", features = ["tls"]}
 tracing = "0.1"
 tracing-attributes = "0.1"
 tracing-futures = "0.2"
 webpki = {version = "0.21",optional = true}
 
 [build-dependencies]
-tonic-build = "0.2"
+tonic-build = "0.4"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dgraph-tonic"
-version = "0.8.7"
+version = "0.9.0"
 authors = ["Selmeci <selmeci.roman@gmail.com>"]
 edition = "2018"
 description = "A rust async/sync client for Dgraph database build with Tonic crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dgraph-tonic"
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Selmeci <selmeci.roman@gmail.com>"]
 edition = "2018"
 description = "A rust async/sync client for Dgraph database build with Tonic crate"

--- a/src/api/v1_0_x/api.rs
+++ b/src/api/v1_0_x/api.rs
@@ -1,14 +1,15 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Request {
     #[prost(string, tag = "1")]
-    pub query: std::string::String,
+    pub query: ::prost::alloc::string::String,
     /// Support for GraphQL like variables.
     #[prost(map = "string, string", tag = "2")]
-    pub vars: ::std::collections::HashMap<std::string::String, std::string::String>,
+    pub vars:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(uint64, tag = "13")]
     pub start_ts: u64,
     #[prost(message, optional, tag = "14")]
-    pub lin_read: ::std::option::Option<LinRead>,
+    pub lin_read: ::core::option::Option<LinRead>,
     #[prost(bool, tag = "15")]
     pub read_only: bool,
     #[prost(bool, tag = "16")]
@@ -16,42 +17,44 @@ pub struct Request {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Response {
-    #[prost(bytes, tag = "1")]
-    pub json: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub json: ::prost::alloc::vec::Vec<u8>,
+    #[deprecated]
     #[prost(message, repeated, tag = "2")]
-    pub schema: ::std::vec::Vec<SchemaNode>,
+    pub schema: ::prost::alloc::vec::Vec<SchemaNode>,
     #[prost(message, optional, tag = "3")]
-    pub txn: ::std::option::Option<TxnContext>,
+    pub txn: ::core::option::Option<TxnContext>,
     #[prost(message, optional, tag = "12")]
-    pub latency: ::std::option::Option<Latency>,
+    pub latency: ::core::option::Option<Latency>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Assigned {
     #[prost(map = "string, string", tag = "1")]
-    pub uids: ::std::collections::HashMap<std::string::String, std::string::String>,
+    pub uids:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(message, optional, tag = "2")]
-    pub context: ::std::option::Option<TxnContext>,
+    pub context: ::core::option::Option<TxnContext>,
     #[prost(message, optional, tag = "12")]
-    pub latency: ::std::option::Option<Latency>,
+    pub latency: ::core::option::Option<Latency>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Mutation {
-    #[prost(bytes, tag = "1")]
-    pub set_json: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub delete_json: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "3")]
-    pub set_nquads: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "4")]
-    pub del_nquads: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub set_json: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub delete_json: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub set_nquads: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub del_nquads: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag = "5")]
-    pub query: std::string::String,
+    pub query: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub cond: std::string::String,
+    pub cond: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "10")]
-    pub set: ::std::vec::Vec<NQuad>,
+    pub set: ::prost::alloc::vec::Vec<NQuad>,
     #[prost(message, repeated, tag = "11")]
-    pub del: ::std::vec::Vec<NQuad>,
+    pub del: ::prost::alloc::vec::Vec<NQuad>,
     #[prost(uint64, tag = "13")]
     pub start_ts: u64,
     #[prost(bool, tag = "14")]
@@ -63,9 +66,9 @@ pub struct Mutation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag = "1")]
-    pub schema: std::string::String,
+    pub schema: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub drop_attr: std::string::String,
+    pub drop_attr: ::prost::alloc::string::String,
     #[prost(bool, tag = "3")]
     pub drop_all: bool,
     #[prost(enumeration = "operation::DropOp", tag = "4")]
@@ -73,8 +76,9 @@ pub struct Operation {
     /// If drop_op is ATTR or TYPE, drop_value holds the name of the predicate or
     /// type to delete.
     #[prost(string, tag = "5")]
-    pub drop_value: std::string::String,
+    pub drop_value: ::prost::alloc::string::String,
 }
+/// Nested message and enum types in `Operation`.
 pub mod operation {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -89,8 +93,8 @@ pub mod operation {
 /// Worker services.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Payload {
-    #[prost(bytes, tag = "1")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxnContext {
@@ -102,19 +106,19 @@ pub struct TxnContext {
     pub aborted: bool,
     /// List of keys to be used for conflict detection.
     #[prost(string, repeated, tag = "4")]
-    pub keys: ::std::vec::Vec<std::string::String>,
+    pub keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// List of predicates involved in this transaction.
     #[prost(string, repeated, tag = "5")]
-    pub preds: ::std::vec::Vec<std::string::String>,
+    pub preds: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "13")]
-    pub lin_read: ::std::option::Option<LinRead>,
+    pub lin_read: ::core::option::Option<LinRead>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Check {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Version {
     #[prost(string, tag = "1")]
-    pub tag: std::string::String,
+    pub tag: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LinRead {
@@ -123,6 +127,7 @@ pub struct LinRead {
     #[prost(enumeration = "lin_read::Sequencing", tag = "2")]
     pub sequencing: i32,
 }
+/// Nested message and enum types in `LinRead`.
 pub mod lin_read {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -145,49 +150,50 @@ pub struct Latency {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NQuad {
     #[prost(string, tag = "1")]
-    pub subject: std::string::String,
+    pub subject: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub predicate: std::string::String,
+    pub predicate: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub object_id: std::string::String,
+    pub object_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "4")]
-    pub object_value: ::std::option::Option<Value>,
+    pub object_value: ::core::option::Option<Value>,
     #[prost(string, tag = "5")]
-    pub label: std::string::String,
+    pub label: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub lang: std::string::String,
+    pub lang: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "7")]
-    pub facets: ::std::vec::Vec<Facet>,
+    pub facets: ::prost::alloc::vec::Vec<Facet>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Value {
     #[prost(oneof = "value::Val", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
-    pub val: ::std::option::Option<value::Val>,
+    pub val: ::core::option::Option<value::Val>,
 }
+/// Nested message and enum types in `Value`.
 pub mod value {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Val {
         #[prost(string, tag = "1")]
-        DefaultVal(std::string::String),
+        DefaultVal(::prost::alloc::string::String),
         #[prost(bytes, tag = "2")]
-        BytesVal(std::vec::Vec<u8>),
+        BytesVal(::prost::alloc::vec::Vec<u8>),
         #[prost(int64, tag = "3")]
         IntVal(i64),
         #[prost(bool, tag = "4")]
         BoolVal(bool),
         #[prost(string, tag = "5")]
-        StrVal(std::string::String),
+        StrVal(::prost::alloc::string::String),
         #[prost(double, tag = "6")]
         DoubleVal(f64),
         /// Geo data in WKB format
         #[prost(bytes, tag = "7")]
-        GeoVal(std::vec::Vec<u8>),
+        GeoVal(::prost::alloc::vec::Vec<u8>),
         #[prost(bytes, tag = "8")]
-        DateVal(std::vec::Vec<u8>),
+        DateVal(::prost::alloc::vec::Vec<u8>),
         #[prost(bytes, tag = "9")]
-        DatetimeVal(std::vec::Vec<u8>),
+        DatetimeVal(::prost::alloc::vec::Vec<u8>),
         #[prost(string, tag = "10")]
-        PasswordVal(std::string::String),
+        PasswordVal(::prost::alloc::string::String),
         #[prost(uint64, tag = "11")]
         UidVal(u64),
     }
@@ -195,18 +201,19 @@ pub mod value {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Facet {
     #[prost(string, tag = "1")]
-    pub key: std::string::String,
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    pub key: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(enumeration = "facet::ValType", tag = "3")]
     pub val_type: i32,
     /// tokens of value.
     #[prost(string, repeated, tag = "4")]
-    pub tokens: ::std::vec::Vec<std::string::String>,
+    pub tokens: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// not stored, only used for query.
     #[prost(string, tag = "5")]
-    pub alias: std::string::String,
+    pub alias: ::prost::alloc::string::String,
 }
+/// Nested message and enum types in `Facet`.
 pub mod facet {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -221,13 +228,13 @@ pub mod facet {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SchemaNode {
     #[prost(string, tag = "1")]
-    pub predicate: std::string::String,
+    pub predicate: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub r#type: std::string::String,
+    pub r#type: ::prost::alloc::string::String,
     #[prost(bool, tag = "3")]
     pub index: bool,
     #[prost(string, repeated, tag = "4")]
-    pub tokenizer: ::std::vec::Vec<std::string::String>,
+    pub tokenizer: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(bool, tag = "5")]
     pub reverse: bool,
     #[prost(bool, tag = "6")]
@@ -242,18 +249,18 @@ pub struct SchemaNode {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginRequest {
     #[prost(string, tag = "1")]
-    pub userid: std::string::String,
+    pub userid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub password: std::string::String,
+    pub password: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub refresh_token: std::string::String,
+    pub refresh_token: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Jwt {
     #[prost(string, tag = "1")]
-    pub access_jwt: std::string::String,
+    pub access_jwt: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub refresh_jwt: std::string::String,
+    pub refresh_jwt: ::prost::alloc::string::String,
 }
 #[doc = r" Generated client implementations."]
 pub mod dgraph_client {

--- a/src/api/v1_1_x/api.rs
+++ b/src/api/v1_1_x/api.rs
@@ -3,21 +3,23 @@ pub struct Request {
     #[prost(uint64, tag = "1")]
     pub start_ts: u64,
     #[prost(string, tag = "4")]
-    pub query: std::string::String,
+    pub query: ::prost::alloc::string::String,
     /// Support for GraphQL like variables.
     #[prost(map = "string, string", tag = "5")]
-    pub vars: ::std::collections::HashMap<std::string::String, std::string::String>,
+    pub vars:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(bool, tag = "6")]
     pub read_only: bool,
     #[prost(bool, tag = "7")]
     pub best_effort: bool,
     #[prost(message, repeated, tag = "12")]
-    pub mutations: ::std::vec::Vec<Mutation>,
+    pub mutations: ::prost::alloc::vec::Vec<Mutation>,
     #[prost(bool, tag = "13")]
     pub commit_now: bool,
     #[prost(enumeration = "request::RespFormat", tag = "14")]
     pub resp_format: i32,
 }
+/// Nested message and enum types in `Request`.
 pub mod request {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -29,50 +31,51 @@ pub mod request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Uids {
     #[prost(string, repeated, tag = "1")]
-    pub uids: ::std::vec::Vec<std::string::String>,
+    pub uids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListOfString {
     #[prost(string, repeated, tag = "1")]
-    pub value: ::std::vec::Vec<std::string::String>,
+    pub value: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Response {
-    #[prost(bytes, tag = "1")]
-    pub json: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub json: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
-    pub txn: ::std::option::Option<TxnContext>,
+    pub txn: ::core::option::Option<TxnContext>,
     #[prost(message, optional, tag = "3")]
-    pub latency: ::std::option::Option<Latency>,
+    pub latency: ::core::option::Option<Latency>,
     /// Metrics contains all metrics related to the query.
     #[prost(message, optional, tag = "4")]
-    pub metrics: ::std::option::Option<Metrics>,
+    pub metrics: ::core::option::Option<Metrics>,
     /// uids contains a mapping of blank_node => uid for the node. It only returns uids
     /// that were created as part of a mutation.
     #[prost(map = "string, string", tag = "12")]
-    pub uids: ::std::collections::HashMap<std::string::String, std::string::String>,
-    #[prost(bytes, tag = "13")]
-    pub rdf: std::vec::Vec<u8>,
+    pub uids:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(bytes = "vec", tag = "13")]
+    pub rdf: ::prost::alloc::vec::Vec<u8>,
     #[prost(map = "string, message", tag = "14")]
-    pub hdrs: ::std::collections::HashMap<std::string::String, ListOfString>,
+    pub hdrs: ::std::collections::HashMap<::prost::alloc::string::String, ListOfString>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Mutation {
-    #[prost(bytes, tag = "1")]
-    pub set_json: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "2")]
-    pub delete_json: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "3")]
-    pub set_nquads: std::vec::Vec<u8>,
-    #[prost(bytes, tag = "4")]
-    pub del_nquads: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub set_json: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub delete_json: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub set_nquads: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub del_nquads: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, repeated, tag = "5")]
-    pub set: ::std::vec::Vec<NQuad>,
+    pub set: ::prost::alloc::vec::Vec<NQuad>,
     #[prost(message, repeated, tag = "6")]
-    pub del: ::std::vec::Vec<NQuad>,
+    pub del: ::prost::alloc::vec::Vec<NQuad>,
     /// This is being used for upserts.
     #[prost(string, tag = "9")]
-    pub cond: std::string::String,
+    pub cond: ::prost::alloc::string::String,
     /// This field is a duplicate of the one in Request and placed here for convenience.
     #[prost(bool, tag = "14")]
     pub commit_now: bool,
@@ -80,9 +83,9 @@ pub struct Mutation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag = "1")]
-    pub schema: std::string::String,
+    pub schema: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub drop_attr: std::string::String,
+    pub drop_attr: ::prost::alloc::string::String,
     #[prost(bool, tag = "3")]
     pub drop_all: bool,
     #[prost(enumeration = "operation::DropOp", tag = "4")]
@@ -90,11 +93,12 @@ pub struct Operation {
     /// If drop_op is ATTR or TYPE, drop_value holds the name of the predicate or
     /// type to delete.
     #[prost(string, tag = "5")]
-    pub drop_value: std::string::String,
+    pub drop_value: ::prost::alloc::string::String,
     /// run indexes in background.
     #[prost(bool, tag = "6")]
     pub run_in_background: bool,
 }
+/// Nested message and enum types in `Operation`.
 pub mod operation {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -109,8 +113,8 @@ pub mod operation {
 /// Worker services.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Payload {
-    #[prost(bytes, tag = "1")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TxnContext {
@@ -122,17 +126,17 @@ pub struct TxnContext {
     pub aborted: bool,
     /// List of keys to be used for conflict detection.
     #[prost(string, repeated, tag = "4")]
-    pub keys: ::std::vec::Vec<std::string::String>,
+    pub keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// List of predicates involved in this transaction.
     #[prost(string, repeated, tag = "5")]
-    pub preds: ::std::vec::Vec<std::string::String>,
+    pub preds: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Check {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Version {
     #[prost(string, tag = "1")]
-    pub tag: std::string::String,
+    pub tag: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Latency {
@@ -151,54 +155,55 @@ pub struct Latency {
 pub struct Metrics {
     /// num_uids is the map of number of uids processed by each attribute.
     #[prost(map = "string, uint64", tag = "1")]
-    pub num_uids: ::std::collections::HashMap<std::string::String, u64>,
+    pub num_uids: ::std::collections::HashMap<::prost::alloc::string::String, u64>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NQuad {
     #[prost(string, tag = "1")]
-    pub subject: std::string::String,
+    pub subject: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub predicate: std::string::String,
+    pub predicate: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub object_id: std::string::String,
+    pub object_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "4")]
-    pub object_value: ::std::option::Option<Value>,
+    pub object_value: ::core::option::Option<Value>,
     #[prost(string, tag = "5")]
-    pub label: std::string::String,
+    pub label: ::prost::alloc::string::String,
     #[prost(string, tag = "6")]
-    pub lang: std::string::String,
+    pub lang: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "7")]
-    pub facets: ::std::vec::Vec<Facet>,
+    pub facets: ::prost::alloc::vec::Vec<Facet>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Value {
     #[prost(oneof = "value::Val", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
-    pub val: ::std::option::Option<value::Val>,
+    pub val: ::core::option::Option<value::Val>,
 }
+/// Nested message and enum types in `Value`.
 pub mod value {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Val {
         #[prost(string, tag = "1")]
-        DefaultVal(std::string::String),
+        DefaultVal(::prost::alloc::string::String),
         #[prost(bytes, tag = "2")]
-        BytesVal(std::vec::Vec<u8>),
+        BytesVal(::prost::alloc::vec::Vec<u8>),
         #[prost(int64, tag = "3")]
         IntVal(i64),
         #[prost(bool, tag = "4")]
         BoolVal(bool),
         #[prost(string, tag = "5")]
-        StrVal(std::string::String),
+        StrVal(::prost::alloc::string::String),
         #[prost(double, tag = "6")]
         DoubleVal(f64),
         /// Geo data in WKB format
         #[prost(bytes, tag = "7")]
-        GeoVal(std::vec::Vec<u8>),
+        GeoVal(::prost::alloc::vec::Vec<u8>),
         #[prost(bytes, tag = "8")]
-        DateVal(std::vec::Vec<u8>),
+        DateVal(::prost::alloc::vec::Vec<u8>),
         #[prost(bytes, tag = "9")]
-        DatetimeVal(std::vec::Vec<u8>),
+        DatetimeVal(::prost::alloc::vec::Vec<u8>),
         #[prost(string, tag = "10")]
-        PasswordVal(std::string::String),
+        PasswordVal(::prost::alloc::string::String),
         #[prost(uint64, tag = "11")]
         UidVal(u64),
     }
@@ -206,18 +211,19 @@ pub mod value {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Facet {
     #[prost(string, tag = "1")]
-    pub key: std::string::String,
-    #[prost(bytes, tag = "2")]
-    pub value: std::vec::Vec<u8>,
+    pub key: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
     #[prost(enumeration = "facet::ValType", tag = "3")]
     pub val_type: i32,
     /// tokens of value.
     #[prost(string, repeated, tag = "4")]
-    pub tokens: ::std::vec::Vec<std::string::String>,
+    pub tokens: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// not stored, only used for query.
     #[prost(string, tag = "5")]
-    pub alias: std::string::String,
+    pub alias: ::prost::alloc::string::String,
 }
+/// Nested message and enum types in `Facet`.
 pub mod facet {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
@@ -232,18 +238,18 @@ pub mod facet {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LoginRequest {
     #[prost(string, tag = "1")]
-    pub userid: std::string::String,
+    pub userid: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub password: std::string::String,
+    pub password: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
-    pub refresh_token: std::string::String,
+    pub refresh_token: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Jwt {
     #[prost(string, tag = "1")]
-    pub access_jwt: std::string::String,
+    pub access_jwt: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
-    pub refresh_jwt: std::string::String,
+    pub refresh_jwt: ::prost::alloc::string::String,
 }
 #[doc = r" Generated client implementations."]
 pub mod dgraph_client {

--- a/src/sync/client/mod.rs
+++ b/src/sync/client/mod.rs
@@ -211,7 +211,7 @@ impl<C: IClient> ClientVariant<C> {
     /// ```
     ///
     pub fn alter(&self, op: Operation) -> Result<Payload> {
-        let mut rt = self.rt.lock().expect("Tokio runtime");
+        let rt = self.rt.lock().expect("Tokio runtime");
         let mut stub = self.any_stub();
         rt.block_on(async move { stub.alter(op).await })
     }
@@ -385,7 +385,7 @@ impl<C: IClient> ClientVariant<C> {
     /// ```
     ///
     pub fn check_version(&self) -> Result<Version> {
-        let mut rt = self.rt.lock().expect("Tokio runtime");
+        let rt = self.rt.lock().expect("Tokio runtime");
         let mut stub = self.any_stub();
         rt.block_on(async move { stub.check_version().await })
     }

--- a/src/sync/txn/best_effort.rs
+++ b/src/sync/txn/best_effort.rs
@@ -34,7 +34,7 @@ impl<C: ILazyClient> IState for BestEffort<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");
@@ -49,7 +49,7 @@ impl<C: ILazyClient> IState for BestEffort<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");

--- a/src/sync/txn/default.rs
+++ b/src/sync/txn/default.rs
@@ -34,7 +34,7 @@ impl<C: ILazyClient> IState for Base<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");
@@ -49,7 +49,7 @@ impl<C: ILazyClient> IState for Base<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");

--- a/src/sync/txn/mutated.rs
+++ b/src/sync/txn/mutated.rs
@@ -52,7 +52,7 @@ impl<C: ILazyClient> IState for Mutated<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");
@@ -67,7 +67,7 @@ impl<C: ILazyClient> IState for Mutated<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");
@@ -539,7 +539,7 @@ pub trait Mutate: Query {
 
 impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
     fn discard(self) -> Result<()> {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = self.extra.async_txn;
         rt.block_on(async move {
             let async_txn = async_txn.lock().expect("MutatedTxn").to_owned();
@@ -548,7 +548,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
     }
 
     fn commit(self) -> Result<()> {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = self.extra.async_txn;
         rt.block_on(async move {
             let async_txn = async_txn.lock().expect("MutatedTxn").to_owned();
@@ -557,7 +557,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
     }
 
     fn mutate(&mut self, mu: Mutation) -> Result<MutationResponse> {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.extra.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("MutatedTxn");
@@ -566,7 +566,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
     }
 
     fn mutate_and_commit_now(self, mu: Mutation) -> Result<MutationResponse> {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = self.extra.async_txn;
         rt.block_on(async move {
             let async_txn = async_txn.lock().expect("MutatedTxn").to_owned();
@@ -580,7 +580,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
         Q: Into<String> + Send + Sync,
         M: Into<UpsertMutation> + Send + Sync,
     {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.extra.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("MutatedTxn");
@@ -594,7 +594,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
         Q: Into<String> + Send + Sync,
         M: Into<UpsertMutation> + Send + Sync,
     {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = self.extra.async_txn;
         rt.block_on(async move {
             let async_txn = async_txn.lock().expect("MutatedTxn").to_owned();
@@ -615,7 +615,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
         V: Into<String> + Send + Sync,
         M: Into<UpsertMutation> + Send + Sync,
     {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.extra.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("MutatedTxn");
@@ -636,7 +636,7 @@ impl<C: ILazyClient> Mutate for TxnMutatedType<C> {
         V: Into<String> + Send + Sync,
         M: Into<UpsertMutation> + Send + Sync,
     {
-        let mut rt = self.extra.rt.lock().expect("Tokio Runtime");
+        let rt = self.extra.rt.lock().expect("Tokio Runtime");
         let async_txn = self.extra.async_txn;
         rt.block_on(async move {
             let async_txn = async_txn.lock().expect("MutatedTxn").to_owned();

--- a/src/sync/txn/read_only.rs
+++ b/src/sync/txn/read_only.rs
@@ -34,7 +34,7 @@ impl<C: ILazyClient> IState for ReadOnly<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");
@@ -49,7 +49,7 @@ impl<C: ILazyClient> IState for ReadOnly<C> {
         K: Into<String> + Send + Sync + Eq + Hash,
         V: Into<String> + Send + Sync,
     {
-        let mut rt = self.rt.lock().expect("Tokio Runtime");
+        let rt = self.rt.lock().expect("Tokio Runtime");
         let async_txn = Arc::clone(&self.async_txn);
         rt.block_on(async move {
             let mut async_txn = async_txn.lock().expect("Async Txn");


### PR DESCRIPTION
I've updated three dependencies as part of this PR - tokio, prost, and tonic.

tokio has recently reached 1.0, and since it's a pretty core library, and differing versions can be problematic across crates, I think updating it to 1.0 ASAP makes the most sense - especially since they have some strong semver guarantees post 1.0.

tonic being updated pulls in the 1.0 of tokio, and also the updated prost 0.7.

I've run all of the integration tests locally and everything passes.